### PR TITLE
[Feat] login 기능 구현

### DIFF
--- a/backend/config/authentication.py
+++ b/backend/config/authentication.py
@@ -1,0 +1,24 @@
+from multiprocessing.sharedctypes import Value
+import jwt
+from django.conf import settings
+from rest_framework import authentication
+from rest_framework import exceptions
+from members.models import Member
+
+class JWTAuthentication(authentication.BaseAuthentication):
+  def authenticate(self, request):
+    try:
+      token = request.META.get("HTTP_AUTHORIZATION")
+      if token is None:
+        return None
+      xjwt, jwt_token = token.split(" ")
+      decoded = jwt.decode(jwt_token, settings.SECRET_KEY, algorithms=["HS256"])
+      pk = decoded.get("pk")
+      member = Member.objects.get(pk=pk)
+      return (member, None)
+    except ValueError: # token이 제대로 보내지지 않은 경우
+      return None
+    except jwt.exceptions.DecodeError: # 잘못된 token을 가지고 decode하는 경우
+      raise exceptions.AuthenticationFailed(detail="JWT Format Invalid")
+    except Member.DoesNotExist:
+      return None

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -149,7 +149,7 @@ AUTH_USER_MODEL = "members.Member"
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         # 'rest_framework.authentication.BasicAuthentication',
-        # 'config.authentication.JWTAuthentication',
+        'config.authentication.JWTAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ]
 }

--- a/backend/members/permissions.py
+++ b/backend/members/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework.permissions import BasePermission
+
+class IsSelf(BasePermission):
+
+  def has_object_permission(self, request, view, member):
+    return member == request.user

--- a/backend/members/urls.py
+++ b/backend/members/urls.py
@@ -1,10 +1,9 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 from . import views
 
 app_name = "members"
 
-urlpatterns = [
-  path("", views.MembersView.as_view()),
-  path("me/", views.MeView.as_view()),
-  path("<int:pk>/", views.member_detail),
-]
+router = DefaultRouter()
+router.register("", views.MemberViewSet)
+urlpatterns = router.urls

--- a/backend/members/views.py
+++ b/backend/members/views.py
@@ -1,42 +1,44 @@
+import jwt
+from django.conf import settings
+from django.contrib.auth import authenticate
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.decorators import api_view
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAdminUser, AllowAny
+from rest_framework.decorators import action
 from .serializers import MemberSerializer
+from .permissions import IsSelf
 from .models import Member
 
-class MembersView(APIView):
-  # create member
-  def post(self, request):
-    serializer = MemberSerializer(data=request.data) # deserializing(JSON->Dict자료형)
-    if serializer.is_valid():
-      new_member = serializer.save()
-      return Response(MemberSerializer(new_member).data)
+class MemberViewSet(ModelViewSet):
+  
+  queryset = Member.objects.all()
+  serializer_class = MemberSerializer
+
+  # 접근 제한
+  def get_permissions(self):
+    permission_classes = []
+    if self.action == "list": # get
+      permission_classes = [IsAdminUser]
+    elif self.action == "create" or self.action == "retrieve": # create, get/<int:pk>
+      permission_classes = [AllowAny]
+    else: # update(put/patch), delete
+      permission_classes = [IsSelf]
+    return [permission() for permission in permission_classes]
+
+  @action(detail=False, methods=['POST'])
+  def login(self, request):
+    username = request.data.get("username")
+    password = request.data.get('password')
+    if not username or not password:
+      return Response(status=status.HTTP_400_BAD_REQUEST)
+    member = authenticate(username=username, password=password)
+    # jwt token 생성
+    if member is not None:
+      encoded_jwt = jwt.encode({"pk":member.pk}, settings.SECRET_KEY, algorithm="HS256")
+      return Response(data={"token":encoded_jwt, "id":member.pk})
     else:
-      return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-class MeView(APIView):
-  permission_classes = [IsAuthenticated]
-  # 내 정보 불러오기
-  def get(self, request):
-    return Response(MemberSerializer(request.user).data)
-
-  # 내 정보 업데이트
-  def put(self, request):
-    serializer = MemberSerializer(request.user, data=request.data, partial=True)
-    print(request.data)
-    if serializer.is_valid():
-      serializer.save()
-      return Response()
-    else:
-      return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-# 유저 정보 확인
-@api_view(["GET"])
-def member_detail(request, pk):
-  try:
-    member = Member.objects.get(pk=pk)
-    return Response(MemberSerializer(member).data)
-  except Member.DoesNotExist:
-    return Response(status=status.HTTP_404_NOT_FOUND)
+      return Response(status=status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
## 관련 이슈

<!-- 깃헙 이슈 번호 연결하실 때는 "#이슈번호" 이런식으로 연결하시면 됩니다 :) -->
#18 

## 요약

<!-- 작업하신 내용을 요약하여 간략히 적어주세요 :) -->
Member View 리팩토링 
 - 기존에 APIView로 각각 구현되어 있던 Member 관련 View들을 하나의 MemberViewSet으로 정리
 - member관련 API에 대한 접근 제한 설정
 
![image](https://user-images.githubusercontent.com/70304727/180454528-e4e43998-3c5a-4f0e-8ff8-730a9f21b483.png)
  - GET api/v1/members/(="list") : 모든 멤버 정보 출력, admin 계정만 접근 가능 
  - POST api/v1/members/(="create") : 멤버 생성(=회원가입), 누구나 접근 가능
  - GET api/v1/members/1/ (="retrieve"): 특정 멤버 정보 조회, 누구나 접근 가능
  - PUT/PATCH api/v1/members/1/(="update") : 멤버 정보 수정, 로그인한 유저만 본인 id에 접근 가능
     -> 제가 테스트해본 결과 PUT보다는 PATCH를 이용하는게 안전한 거 같습니다. ** (`추가 논의 필요!`) 
  - DELETE api/v1/members/1/(="delete") : 멤버 삭제(=회원 탈퇴), 로그인한 유저만 본인 id에 접근 가능

Login 기능 구현
![image](https://user-images.githubusercontent.com/70304727/180455788-6ec61d11-bc82-417d-99c9-a15cde06bbcb.png)
- 간략히만 설명드리면, POST로 입력받은 정보 중에서 username과 password를 가져와서 `django.contrib.auth`가 제공하는 authenticate() 메서드로 멤버 확인을 합니다. 
- 만약 DB에 해당 username과 일치하는 password가 저장되어 있다면 member 객체를 리턴하고, 리턴된 member객체 정보(=pk 값)를 가지고 JWT token을 발행합니다. 
- 그리고 Response로 `jwt_token`과 `pk` 값을 리턴하면, 클라이언트에서는 해당 `jwt_token`을 어딘가에 저장해놓고(일반적으로 session storage라고 하는데, 그 외에도 여러가지 방법이 있다고 합니다**), 다른 API를 사용할 때마다 header에 jwt_token을 같이 넣어서 서버에 보냅니다.
- 서버는 jwt_token을 확인해서 token이 유효한지 확인한 뒤 유효하면 Response를 내려주고, 아니면 권한없음 에러를 내보냅니다.
- 현재 코드에서 사용 예시
   1. 로그인함
   2. 성공적으로 로그인되면 Response로 'jwt_token'과 '본인id값'을 반환함
   3. header에 `Authorization : X-JWT(공백)jwt_token` 정보를 넣고 PATCH api/v1/members/본인id값/ 을 호출하고 body에 수정할 정보를 입력({m_intro : "jwt테스트입니다"})함

*정리*
- 검색해보니 백엔드에서 로그인 처리를 하는 부분은 이정도라고 합니다.
![image](https://user-images.githubusercontent.com/70304727/180460984-f0b44d86-25bd-441e-97fb-d194bdfc14f3.png)
- 즉, JWT Token을 발급받아서 header에 넣고 API를 호출하는 상태가 로그인 상태인 셈입니다.
- 이후 프론트 단에서 (유저에게 보여지는) 로그인 유지 상태, 로그인 탈퇴 기능을 구현해주셔야 할 듯 합니다.
- 추가로 jwt access token 외에 refresh token이라는 게 있던데 아직 적용하지는 않았습니다. (추가로 DB를 써야 한다느니 여러가지 말들이 많더군요..) 해당 refresh token 부분은 프론트팀에서 테스트한 뒤 논의를 통해 구현하도록 하겠습니다!

REF
- https://tansfil.tistory.com/58?category=475681
- https://velog.io/@junghyeonsu/프론트에서-로그인을-처리하는-방법
- https://velog.io/@yaytomato/프론트에서-안전하게-로그인-처리하기